### PR TITLE
Do not include node explorer in the exported tiddler

### DIFF
--- a/source/shiraz/viewtemplates/$__plugins_kookma_viewtemplates_node-explorer-details.tid
+++ b/source/shiraz/viewtemplates/$__plugins_kookma_viewtemplates_node-explorer-details.tid
@@ -1,0 +1,27 @@
+code-body: yes
+created: 20210501201700405
+modified: 20221012131832464
+tags: 
+title: $:/plugins/kookma/viewtemplates/node-explorer-details
+type: text/vnd.tiddlywiki
+
+\import $:/plugins/kookma/viewtemplates/node-explorer
+
+<!-- hide node expolorer when a tiddler is exported  -->
+<$list filter="[<tv-config-toolbar-icons>prefix[yes]]" variable=0>
+
+<$list filter="[all[current]get[node-explorer]!match[hide]] [all[current]!has[node-explorer]]" variable=null>
+<$list filter="[subfilter<mainFilter>] +[count[]compare:number:gteq[1]]" variable=null>
+
+<$macrocall 
+  $name=details 
+  label="Node Explorer"
+  status=""
+  labelClass="alert alert-secondary py-1 my-2"
+	srcClass  ="alert border-secondary py-0"
+  src={{$:/plugins/kookma/viewtemplates/node-explorer}}
+  />
+
+</$list>
+</$list>
+</$list>


### PR DESCRIPTION
Hide node explorer in the exported HTML

 When a tiddler is exported in HTML and the tiddler had "Node Explorer" enabled then it becomes part of the exported HTML.


 This PR removes the "Node Explorer" from the exported HTML.

Node explorer does not have any use in an individual HTML tidder.